### PR TITLE
Fix Class Rename Refactor with Resources

### DIFF
--- a/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RenameClassRefactoring.cls
+++ b/Core/Contributions/Refactory/Refactoring Browser/Refactorings/RenameClassRefactoring.cls
@@ -26,6 +26,7 @@ renameReferences
 	| replacer |
 	replacer := (ParseTreeRewriter replaceLiteral: className with: newName)
 				replace: className with: newName;
+				replace: 'Smalltalk.' , className with: 'Smalltalk.' , newName;
 				replaceArgument: newName
 					withValueFrom: 
 						[:aNode | 


### PR DESCRIPTION
Fix for class rename refactor not changing class references in view resource code.  I added a replace for 'Smalltalk.' , className . This now changes class references in view resources.  

It seems impure to hard code the 'Smalltalk.' prefix.  I think this notation was a starting point for potentially supporting multiple namespaces but I could not find an easy way to get a classes namespace.  Someone with a broader understanding may be able to improve the elegance of this fix.